### PR TITLE
feat: add `minimumSupportAppVersion` field

### DIFF
--- a/schema/src/schema.json
+++ b/schema/src/schema.json
@@ -32,7 +32,7 @@
             "type": "object",
             "properties": {
               "ios": {
-                "type": "string"
+                "$ref": "https://raw.githubusercontent.com/microsoft/json-schemas/main/spfx/semver.schema.json"
               },
               "android": {
                 "type": "string"

--- a/schema/src/schema.json
+++ b/schema/src/schema.json
@@ -32,10 +32,10 @@
             "type": "object",
             "properties": {
               "ios": {
-                "$ref": "https://raw.githubusercontent.com/microsoft/json-schemas/main/spfx/semver.schema.json"
+                "$ref": "https://developer.microsoft.com/json-schemas/spfx/semver.schema.json"
               },
               "android": {
-                "type": "string"
+                "$ref": "https://developer.microsoft.com/json-schemas/spfx/semver.schema.json"
               }
             }
           }

--- a/schema/src/schema.json
+++ b/schema/src/schema.json
@@ -27,6 +27,17 @@
           },
           "response": {
             "$ref": "http://json-schema.org/draft-07/schema#"
+          },
+          "minimumSupportAppVersion": {
+            "type": "object",
+            "properties": {
+              "ios": {
+                "type": "string"
+              },
+              "android": {
+                "type": "string"
+              }
+            }
           }
         },
         "required": ["operationId", "description", "requestBody", "response"],


### PR DESCRIPTION
Adds an optional `minimumSupportAppVersion` field for the queries.
It could be used as a metadata for determining whether the current native app supports those queries or not.